### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     },
     "license": "MIT",
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.0"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,11 @@
-<phpunit colors="true" forceCoversAnnotation="true">
-    <testsuite name="Unit Tests">
-        <directory>./tests</directory>
-    </testsuite>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuite name="Unit Tests">
+    <directory>./tests</directory>
+  </testsuite>
 </phpunit>

--- a/tests/BooleansTest.php
+++ b/tests/BooleansTest.php
@@ -40,33 +40,33 @@ final class BooleansTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      */
     public function filterAllowNullIsFalseAndNullValue()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         $this->assertNull(Booleans::filter(null, false));
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage "1" $value is not a string
      */
     public function filterNonStringAndNonBoolValue()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('"1" $value is not a string');
         Booleans::filter(1);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage invalid is not 'true' or 'false' disregarding case and whitespace
      */
     public function filterInvalidString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("invalid is not 'true' or 'false' disregarding case and whitespace");
         Booleans::filter('invalid');
     }
 
@@ -91,11 +91,11 @@ final class BooleansTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage true is not 'y' or '1' or 'n' or '0' disregarding case and whitespace
      */
     public function filterCustomBoolValuesInvalidString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("true is not 'y' or '1' or 'n' or '0' disregarding case and whitespace");
         $this->assertFalse(Booleans::filter('true', false, ['y', '1'], ['n', '0']));
     }
 


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8
Backwards breaking; Remove Support for PHP 7.2 and earlier
Upgrade to PHPUnit 9

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

